### PR TITLE
fix(lang): use correct German localization

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -4,7 +4,7 @@
     "description": "Name of the extension."
   },
   "extensionDescription": {
-    "message": "Houd je sessie levend op elke website en word nooit uitgelogd ...",
+    "message": "Halte deine Sessions auf jeder Website aktiv und werde nie mehr ausgeloggt ...",
     "description": "Description of the extension."
   },
   "settingsHeading": {
@@ -12,15 +12,15 @@
     "description": "Settings heading."
   },
   "noRunningRulesInfo": {
-    "message": "Er zijn geen regels actief! Klik op de knop Einstellungen om nieuwe regels toe te voegen.",
+    "message": "Es sind keine Regeln aktiv! Klicke auf die Schaltfläche Einstellungen, um neue Regeln hinzuzufügen.",
     "description": "No rules running info message."
   },
   "aliveDivTitle": {
-    "message": "Geplande pagina Opnieuw laden om de sessie levendig te houden!",
+    "message": "Geplantes Neuladen der Seite, um die Sitzung am Leben zu erhalten!",
     "description": "Content Script Alive Div tool-tip."
   },
   "aliveDivContent": {
-    "message": "Klik om de pagina opnieuw in te sluimeren gedurende 1 minuut",
+    "message": "Klicken, um Neuladen der Seite für eine Minute zu pausieren",
     "description": "Content Script Alive Div mouse hover info message."
   }
 }


### PR DESCRIPTION
Previously the German translation file used Dutch translations. This commit updates the translation to actual German.